### PR TITLE
Finish mocha spec reporter, add winston for npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Jay Hogan <seeker136@gmail.com>",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec"
+    "test": "./node_modules/.bin/mocha --reporter spec 'test/index.js' "
   },
   "keywords": [
     "kroger",
@@ -27,8 +27,10 @@
   ],
   "dependencies": {
     "lodash": "^4.17.3",
+    "mocha": "^3.2.0",
+    "request-debug": "^0.2.0",
     "request-promise": "^4.1.1",
-    "request-debug": "^0.2.0"
+    "winston": "^2.3.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -27,14 +27,13 @@
   ],
   "dependencies": {
     "lodash": "^4.17.3",
-    "mocha": "^3.2.0",
     "request-debug": "^0.2.0",
-    "request-promise": "^4.1.1",
-    "winston": "^2.3.1"
+    "request-promise": "^4.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "dotenv": "^2.0.0",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "winston": "^2.3.1"
   }
 }


### PR DESCRIPTION
Hi Jay!  I had some difficulty with the test, but found that adding 'test/index.js' to the mocha --reporter spec and adding the winston dev deps fixed it.  Thought I'd pass this along.

The ClickList client is great!  Nicely done.

Disregard the line-swapping on 30, 31 and 36; I originally did an npm install --save to deps instead of devDeps, and fixed it.